### PR TITLE
Fix :fullscreen documentation

### DIFF
--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -23,41 +23,59 @@ The `:fullscreen` pseudo-class lets you configure your stylesheets to automatica
 
 ## Examples
 
-In this example, the color of a button is changed depending on whether or not the document is in fullscreen mode. This is done without needing to specifically apply style changes using JavaScript.
+In this example, the color of a button is changed depending on whether or not it's parent div is in fullscreen mode. This is done without needing to specifically apply style changes using JavaScript.
 
 ### HTML
 
 The page's HTML looks like this:
 
 ```html
-<h1>MDN Web Docs Demo: :fullscreen pseudo-class</h1>
+<div style="background-color: lightyellow">
+  <h1>MDN Web Docs Demo: :fullscreen pseudo-class</h1>
 
-<p>
-  This demo uses the <code>:fullscreen</code> pseudo-class to automatically
-  change the style of a button used to toggle fullscreen mode on and off,
-  entirely using CSS.
-</p>
+  <p>
+    This demo uses the <code>:fullscreen</code> pseudo-class to automatically
+    change the style of a button used to toggle fullscreen mode on and off,
+    entirely using CSS.
+  </p>
 
-<button id="fs-toggle">Toggle Fullscreen</button>
+  <button id="fs-toggle">Toggle Fullscreen</button>
+</div>
 ```
 
-The {{HTMLElement("button")}} with the ID `"fs-toggle"` will change between pale red and pale green depending on whether or not the document is in fullscreen mode.
+The {{HTMLElement("button")}} with the ID `"fs-toggle"` will change between light pink and light green depending on whether or not the parent div is in fullscreen mode.
+
+### Javascript
+
+For this example, we need the button click to toggle parent div to and from fullscreen mode:
+
+```js
+document.querySelector('#fs-toggle').addEventListener('click', function (event) {
+    if (document.fullscreenElement) {
+        // If there is a fullscreen element, exit full screen.
+        document.exitFullscreen();
+        return;
+    }
+    // Make the parent div fullscreen.
+    event.target.parentElement.requestFullscreen();
+});f
+```
 
 ### CSS
 
 The magic happens in the CSS. There are two rules here. The first establishes the background color of the "Toggle Fullscreen Mode" button when the element is not in a fullscreen state. The key is the use of the `:not(:fullscreen)`, which looks for the element to not have the `:fullscreen` pseudo-class applied to it.
 
 ```css
-#fs-toggle:not(:fullscreen) {
-  background-color: #afa;
+div:not(:fullscreen) #fs-toggle {
+  background-color: lightgreen;
 }
 ```
 
-When the document _is_ in fullscreen mode, the following CSS applies instead, setting the background color to a pale shade of red.
+When the parent div _is_ in fullscreen mode, the following CSS applies instead, setting the background color to light pink.
 
 ```css
-#fs-toggle:fullscreen {
-  background-color: #faa;
+div:fullscreen #fs-toggle {
+  background-color: lightpink;
 }
 ```
 


### PR DESCRIPTION
### Description
Fix both the example and description of the :fullscreen pseudo class page.

### Motivation

Problems:
* The example doesn't work without Javascript but the script is not provided.
* The description of :fullscreen pseudo class is wrong. The pseudo class does not activate when the browser or document is in fullscreen mode at all. It matches **element** that is fullscreen.

Fixes:
* Add javascript and a parent element for the Fullscreen API to work with. Parent element is not required but it better demonstrates the nature of the whole API set.
* Correct the descriptions.
* Use color name instead of rgb to improve readability of the example.


### Additional details

From the specification of :fullscreen, [5.1](https://fullscreen.spec.whatwg.org/#:fullscreen-pseudo-class):

<blockquote>
The :fullscreen pseudo-class must match any [element](https://dom.spec.whatwg.org/#concept-element) element for which one of the following conditions is true:

*  element’s [fullscreen flag](https://fullscreen.spec.whatwg.org/#fullscreen-flag) is set.

* element is a [shadow host](https://dom.spec.whatwg.org/#element-shadow-host) and the result of [retargeting](https://dom.spec.whatwg.org/#retarget) its [node document](https://dom.spec.whatwg.org/#concept-node-document)’s [fullscreen element](https://fullscreen.spec.whatwg.org/#fullscreen-element) against element is element.
</blockquote>

### Related issues and pull requests

Fixes #29950

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
